### PR TITLE
Descheduling mulh

### DIFF
--- a/gcc/config/riscv/bsg_vanilla_2020.md
+++ b/gcc/config/riscv/bsg_vanilla_2020.md
@@ -85,6 +85,12 @@
        (eq_attr "type" "imul"))
   "bsg_vanilla_2020_alu")
 
+;; mulh
+;; Try to deschedule because unsupported in hardware
+(define_insn_reservation "bsg_vanilla_2020_mulh" 1000
+  (and (eq_attr "tune" "bsg_vanilla_2020")
+       (eq_attr "type" "imulh"))
+  "bsg_vanilla_2020_alu")
 
 ;; i2f 
 (define_insn_reservation "bsg_vanilla_2020_i2f" 3

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -140,6 +140,7 @@
 ;; shift	integer shift instructions
 ;; slt		set less than instructions
 ;; imul		integer multiply 
+;; imulh    integer multiply (high half) 
 ;; idiv		integer divide
 ;; move		integer register move (addi rd, rs1, 0)
 ;; fmove	floating point register move
@@ -155,7 +156,7 @@
 ;; ghost	an instruction that produces no real code
 (define_attr "type"
   "unknown,branch,jump,call,load,fpload,store,fpstore,
-   mtc,mfc,const,arith,logical,shift,slt,imul,idiv,move,fmove,fadd,fmul,
+   mtc,mfc,const,arith,logical,shift,slt,imul,imulh,idiv,move,fmove,fadd,fmul,
    fmadd,fdiv,fcmp,fcvt,fsqrt,multi,auipc,sfb_alu,nop,ghost"
   (cond [(eq_attr "got" "load") (const_string "load")
 
@@ -661,7 +662,7 @@
 	    (const_int 64))))]
   "TARGET_MUL && TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
-  [(set_attr "type" "imul")
+  [(set_attr "type" "imulh")
    (set_attr "mode" "DI")])
 
 (define_expand "usmulditi3"
@@ -692,7 +693,7 @@
 	    (const_int 64))))]
   "TARGET_MUL && TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
-  [(set_attr "type" "imul")
+  [(set_attr "type" "imulh")
    (set_attr "mode" "DI")])
 
 (define_expand "<u>mulsidi3"
@@ -722,7 +723,7 @@
 	    (const_int 32))))]
   "TARGET_MUL && !TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
-  [(set_attr "type" "imul")
+  [(set_attr "type" "imulh")
    (set_attr "mode" "SI")])
 
 
@@ -753,7 +754,7 @@
 	    (const_int 32))))]
   "TARGET_MUL && !TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
-  [(set_attr "type" "imul")
+  [(set_attr "type" "imulh")
    (set_attr "mode" "SI")])
 
 ;;


### PR DESCRIPTION
This PR drastically increases the cost of MULH, which is not implemented in vanilla cores. This has the effect of making the compiler infer sequences of MULs rather than MULH itself. It could be considered a workaround, but it's much less work than actually disabling the instruction in the compiler, which would never get upstreamed.

Fixes #2 